### PR TITLE
 Iteration of sheets problem and bugfix

### DIFF
--- a/xlsx/__init__.py
+++ b/xlsx/__init__.py
@@ -29,7 +29,7 @@ class Workbook(object):
         sheets = workbookDoc.firstChild.getElementsByTagName("sheets")[0]
         for sheetNode in sheets.childNodes:
             name = sheetNode._attrs["name"].value
-            id = int(sheetNode._attrs["r:id"].value[3:])
+            id = int(sheetNode._attrs["sheetId"].value)
 
             sheet = Sheet(self, id, name)
             self.__sheetsById[id] = sheet


### PR DESCRIPTION
Fixed problem with iteration. If sheet ids start with 1 or any other number and not 0 there will be an indexing problem.
Fixed a function call bug.
Added **iter** to Workbook
The sheetId attribute in the sheet node is the correct sheet id
