### PR TITLE
Closing workbooks

### DIFF
--- a/xlsx/__init__.py
+++ b/xlsx/__init__.py
@@ -68,6 +68,9 @@ class Workbook(object):
 
     def keys(self):
         return self.__sheetsByName.keys()
+        
+    def close(self):
+        self.domzip.__del__()
 
     def __len__(self):
         return len(self.__sheetsByName)


### PR DESCRIPTION
Using this to parse some XLSX files, then move them into another directory. When it got to the move, I was receiving a Windows error about the file was already in use by another process when I tried to move them.

So, I added a method, close(), to the Workbook object, that calls the internal method already set up. This is my first ever pull request, so if I've done something wrong.. please let me know.
