### PR TITLE
setup.py fails with following error unless keys are removed.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,4 @@ setup(
     packages=[
         "xlsx"
     ],
-    zip_safe=False,
-    include_package_data=True,
 )


### PR DESCRIPTION
These are the warnings given:
/usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown
distribution option: 'include_package_data'
  warnings.warn(msg)
/usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown
distribution option: 'zip_safe'
  warnings.warn(msg)

Removing the two keys, pip installation succeeds.
