### PR TITLE
Return all rows, including empty rows while iterating.

### DIFF
--- a/xlsx/__init__.py
+++ b/xlsx/__init__.py
@@ -176,7 +176,7 @@ class Sheet(object):
                             stringIndex = columnNode[0].text
                             data = self.workbook.sharedStrings[int(stringIndex)]
                         #Built in date-formatted fields
-                        elif cellS and re.match("^[\d\.]+$", columnNode[0].text):
+                        elif cellS and columnNode[0].text and re.match("^[\d\.]+$", columnNode[0].text):
                             if int(self.workbook.cellStyles[int(cellS)].get('numFmtId')) in range(14, 22+1):
                                 data = xldate_as_tuple(
                                     float(columnNode[0].text),

--- a/xlsx/__init__.py
+++ b/xlsx/__init__.py
@@ -153,9 +153,16 @@ class Sheet(object):
         sheetDoc = self.workbook.domzip["xl/worksheets/sheet%d.xml" % self.id]
         sheetData = sheetDoc.find("{http://schemas.openxmlformats.org/spreadsheetml/2006/main}sheetData")
         # @type sheetData Element
+        rowCount = 0
         for rowNode in sheetData:
             rowNum = int(rowNode.get("r"))
             rowCells = []
+
+            rowCount += 1
+            while rowCount < rowNum:
+              yield rowCount, []
+              rowCount += 1
+
             for columnNode in rowNode:
                 colType = columnNode.get("t")
                 cellId = columnNode.get("r")

--- a/xlsx/__init__.py
+++ b/xlsx/__init__.py
@@ -7,7 +7,7 @@ __author__="Ståle Undheim <staale@staale.org>"
 
 import re
 import zipfile
-from xlsx.xldate import xldate_as_tuple
+from xlsx.xldate import xldate_as_python
 from xlsx.formatting import is_date_format_string
 from xlsx.timemachine import UnicodeMixin
 
@@ -178,12 +178,12 @@ class Sheet(object):
                         #Built in date-formatted fields
                         elif cellS and columnNode[0].text and re.match("^[\d\.]+$", columnNode[0].text):
                             if int(self.workbook.cellStyles[int(cellS)].get('numFmtId')) in range(14, 22+1):
-                                data = xldate_as_tuple(
+                                data = xldate_as_python(
                                     float(columnNode[0].text),
                                     datemode=0)
                             elif (self.workbook.cellStyles[int(cellS)].get('numFmtId') in self.workbook.numFmts) \
                                 and is_date_format_string(self.workbook.numFmts[self.workbook.cellStyles[int(cellS)].get('numFmtId')]):
-                                data = xldate_as_tuple(
+                                data = xldate_as_python(
                                     float(columnNode[0].text),
                                     datemode=0)
                             else:

--- a/xlsx/xldate.py
+++ b/xlsx/xldate.py
@@ -18,6 +18,7 @@
 #    Noon on Gregorian 1900-03-01 (day 61 in the 1900-based system) is JDN 2415080.0
 #    Noon on Gregorian 1904-01-02 (day  1 in the 1904-based system) is JDN 2416482.0
 
+from datetime import date, datetime
 from xlsx.timemachine import int_floor_div as ifd
 
 _JDN_delta = (2415080 - 61, 2416482 - 1)
@@ -52,6 +53,15 @@ _XLDAYS_TOO_LARGE = (2958466, 2958466 - 1462) # This is equivalent to 10000-01-0
 # @throws XLDateTooLarge Gregorian year 10000 or later
 # @throws XLDateBadDatemode datemode arg is neither 0 nor 1
 # @throws XLDateError Covers the 4 specific errors
+
+
+def xldate_as_python(xldate, datemode):
+  value = xldate_as_tuple(xldate, datemode)
+  if any(value[3:]):
+    return datetime(*value)
+  else:
+    return date(*value[:3])
+
 
 def xldate_as_tuple(xldate, datemode):
     if datemode not in (0, 1):


### PR DESCRIPTION
Rows not in JSON are just empty rows, return them to align row counts correctly with other tools.
Empty rows are not stored to save space, this patch returns an empty row when the row number skips empty rows.

This is critical when coding offsets, skipped rows make it difficult to use other tools to inspect the sheets and then code the offsets based on actual row numbers.